### PR TITLE
Added missing 442 and 650

### DIFF
--- a/fahrzeuge.csv
+++ b/fahrzeuge.csv
@@ -240,6 +240,7 @@ uic_number;coachgroup;given_name;special_features;comments
 ;ICE8022;Waldecker Land;;
 ;ICE8029;Europa/Europe;;
 ;ICE9006;Martin Luther;;
+;ICE9009;Cottbus/Chóśebuz;;
 ;ICE9018;Freistaat Bayern;;
 ;ICE9025;Nordrhein-Westfalen;;
 ;ICE9026;Zürichsee;;

--- a/fahrzeuge.csv
+++ b/fahrzeuge.csv
@@ -316,6 +316,8 @@ uic_number;coachgroup;given_name;special_features;comments
 94800442206;T0442206;Neef;;
 94800442207;T0442207;Kobern Gondorf;;
 94800442208;T0442208;Winningen;;
+95800650131;;Lily;;
+95800650132;;Frida;;
 95800650501;;Wartburgstadt Eisenach;;
 95800650502;;Theaterstadt Meiningen, Dampflokwelt;;
 95800650503;;Heilklimatischer Kurort Friedrichroda / Marienglashöhle;;

--- a/fahrzeuge.csv
+++ b/fahrzeuge.csv
@@ -303,6 +303,17 @@ uic_number;coachgroup;given_name;special_features;comments
 94800430077;T0430077;;Karriere-S-Bahn Stuttgart;
 94800430087;T0430087;;Karriere-S-Bahn Stuttgart;
 94800430166;T0430166;;Kinder-Malwettbewerb S-Bahn Rhein-Main;
+94800442001;T0442001;Oberbillig;;
+94800442002;T0442002;Ediger-Eller;;
+94800442003;T0442003;Nittel;;
+94800442004;T0442004;Klotten;;
+94800442005;T0442005;Lehmen;;
+94800442202;T0442202;Moselkern;;
+94800442203;T0442203;Pommern;;
+94800442205;T0442205;Ürzig;;
+94800442206;T0442206;Neef;;
+94800442207;T0442207;Kobern Gondorf;;
+94800442208;T0442208;Winningen;;
 95800650501;;Wartburgstadt Eisenach;;
 95800650502;;Theaterstadt Meiningen, Dampflokwelt;;
 95800650503;;Heilklimatischer Kurort Friedrichroda / Marienglashöhle;;

--- a/fahrzeuge.csv
+++ b/fahrzeuge.csv
@@ -311,6 +311,7 @@ uic_number;coachgroup;given_name;special_features;comments
 94800442005;T0442005;Lehmen;;
 94800442202;T0442202;Moselkern;;
 94800442203;T0442203;Pommern;;
+94800442204;T0442204;Müden;;
 94800442205;T0442205;Ürzig;;
 94800442206;T0442206;Neef;;
 94800442207;T0442207;Kobern Gondorf;;


### PR DESCRIPTION
Die wohl letzte fehlende 442 der DB Regio AG Mitte, die auf der Moselstrecke unterwegs ist, eingepflegt

Die beiden 650er, die auf der Moselweinbahn unterwegs sind, hinzugefügt